### PR TITLE
remove custom chunk for answer_rmd 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Imports: htmltools, rmarkdown, stringr
 License: GPL-3
 Encoding: UTF-8
 LazyData: TRUE
-RoxygenNote: 6.1.0
+RoxygenNote: 7.0.2
 URL: https://github.com/koncina/unilur
 BugReports: https://github.com/koncina/unilur/issues
 Suggests: testthat

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Breaking changes
 
+- remove from `answer_rmd` the chunk child that could be used to specify custom boxes and that students don't need
 - replace `question_suffix` and `solution_suffix` by `suffix` in `unilur::tutorial_*` or `unilur::tutorial_*_solution` to change the suffix appended to the rendered file.
 - remove `box.colour` chunk option (replaced by `box.body` and `box.header` which accepts a list to define `fill` and `colour`)
 - The automatic adjustement of header colour changes: `box.colour` was used to define the header colour and the colour of the body was derived from this value. From now, if `box.header` is omitted, the `fill` colour is derived from the `box.body` fill colour.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Breaking changes
 
-- remove from `answer_rmd` the chunk child that could be used to specify custom boxes and that students don't need
+- add option to remove from `answer_rmd` specific chunks
 - replace `question_suffix` and `solution_suffix` by `suffix` in `unilur::tutorial_*` or `unilur::tutorial_*_solution` to change the suffix appended to the rendered file.
 - remove `box.colour` chunk option (replaced by `box.body` and `box.header` which accepts a list to define `fill` and `colour`)
 - The automatic adjustement of header colour changes: `box.colour` was used to define the header colour and the colour of the body was derived from this value. From now, if `box.header` is omitted, the `fill` colour is derived from the `box.body` fill colour.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,11 @@
 # Unilur 0.4.0.9000
 
+## Changes
+
+- add an option `exclude_chunk` to remove from `answer_rmd` specific chunks
+
 ## Breaking changes
 
-- add option to remove from `answer_rmd` specific chunks
 - replace `question_suffix` and `solution_suffix` by `suffix` in `unilur::tutorial_*` or `unilur::tutorial_*_solution` to change the suffix appended to the rendered file.
 - remove `box.colour` chunk option (replaced by `box.body` and `box.header` which accepts a list to define `fill` and `colour`)
 - The automatic adjustement of header colour changes: `box.colour` was used to define the header colour and the colour of the body was derived from this value. From now, if `box.header` is omitted, the `fill` colour is derived from the `box.body` fill colour.

--- a/R/answer_rmd.R
+++ b/R/answer_rmd.R
@@ -6,10 +6,12 @@
 #' 
 #' @param suffix Suffix which is added to the filename (default is '_answer')
 #' 
+#' @param exclude keyword for specific chunks that need to be excluded in answer templates (default NULL)
+#' 
 #' @return R Markdown output format to pass to \code{\link[rmarkdown]{render}}
 #' 
 #' @export
-answer_rmd <- function(yaml = NULL, suffix = "_answer") {
+answer_rmd <- function(yaml = NULL, suffix = "_answer", exclude = NULL) {
   # Here we implement a fake knitting: I don't think it's possible to avoid using pandoc
   # We will generate a simple md document (that will be deleted) and use a chunk hook
   # to disable any code evaluation (to speed up the unnecessary knitting)
@@ -36,9 +38,11 @@ answer_rmd <- function(yaml = NULL, suffix = "_answer") {
     pattern <- "\\n *``` *{.*(?i)(eval|echo|include)(?-i) *= *(?i)false(?-i).*} *\\n[\\s\\S]*?\\n *``` *"
     replacement <- ""
     rmd <- gsub(pattern, replacement, rmd, perl = TRUE)
-    # Removing the chunk with child as students don't have/need it
-    pattern <- " *``` *{.*(?i)setup_practical(?-i).*} *\\n[\\s\\S]*?``` *"
-    rmd <- gsub(pattern, replacement, rmd, perl = TRUE)
+    if (!is.null(exclude)) {
+      # Removing chunk with specific keyword user provided
+      pattern <- paste0(" *``` *{.*(?i)", as.character(exclude), "(?-i).*} *\\n[\\s\\S]*?``` *")
+      rmd <- gsub(pattern, "", rmd, perl = TRUE)
+    }
     # Replacing the original header by a custom one...
     pattern <- "^--- *\\n[\\s\\S]*?\\n *--- *"
     # header <- "---\ntitle: \"My answers\"\nauthor: \"My name\"\ndate: `r format(Sys.time(), \"%d %B, %Y\")`\noutput:\n\tunilur::tutorial_pdf:\n\t\tanswer: yes\n---"

--- a/R/answer_rmd.R
+++ b/R/answer_rmd.R
@@ -11,7 +11,7 @@
 #' @return R Markdown output format to pass to \code{\link[rmarkdown]{render}}
 #' 
 #' @export
-answer_rmd <- function(yaml = NULL, suffix = "_answer", exclude = NULL) {
+answer_rmd <- function(yaml = NULL, suffix = "_answer", exclude_chunk = NULL) {
   # Here we implement a fake knitting: I don't think it's possible to avoid using pandoc
   # We will generate a simple md document (that will be deleted) and use a chunk hook
   # to disable any code evaluation (to speed up the unnecessary knitting)
@@ -38,9 +38,11 @@ answer_rmd <- function(yaml = NULL, suffix = "_answer", exclude = NULL) {
     pattern <- "\\n *``` *{.*(?i)(eval|echo|include)(?-i) *= *(?i)false(?-i).*} *\\n[\\s\\S]*?\\n *``` *"
     replacement <- ""
     rmd <- gsub(pattern, replacement, rmd, perl = TRUE)
-    if (!is.null(exclude)) {
+    if (!is.null(exclude_chunk)) {
       # Removing chunk with specific keyword user provided
-      pattern <- paste0(" *``` *{.*(?i)", as.character(exclude), "(?-i).*} *\\n[\\s\\S]*?``` *")
+      pattern <- paste0(" *``` *{.*(?i)", 
+                        as.character(exclude_chunk),
+                        "(?-i).*} *\\n[\\s\\S]*?``` *")
       rmd <- gsub(pattern, "", rmd, perl = TRUE)
     }
     # Replacing the original header by a custom one...

--- a/R/answer_rmd.R
+++ b/R/answer_rmd.R
@@ -6,7 +6,7 @@
 #' 
 #' @param suffix Suffix which is added to the filename (default is '_answer')
 #' 
-#' @param exclude keyword for specific chunks that need to be excluded in answer templates (default NULL)
+#' @param exclude_chunk keyword to use for excluding specific chunks in answer templates (default NULL)
 #' 
 #' @return R Markdown output format to pass to \code{\link[rmarkdown]{render}}
 #' 

--- a/R/answer_rmd.R
+++ b/R/answer_rmd.R
@@ -36,6 +36,9 @@ answer_rmd <- function(yaml = NULL, suffix = "_answer") {
     pattern <- "\\n *``` *{.*(?i)(eval|echo|include)(?-i) *= *(?i)false(?-i).*} *\\n[\\s\\S]*?\\n *``` *"
     replacement <- ""
     rmd <- gsub(pattern, replacement, rmd, perl = TRUE)
+    # Removing the chunk with child as students don't have/need it
+    pattern <- " *``` *{.*(?i)setup_practical(?-i).*} *\\n[\\s\\S]*?``` *"
+    rmd <- gsub(pattern, replacement, rmd, perl = TRUE)
     # Replacing the original header by a custom one...
     pattern <- "^--- *\\n[\\s\\S]*?\\n *--- *"
     # header <- "---\ntitle: \"My answers\"\nauthor: \"My name\"\ndate: `r format(Sys.time(), \"%d %B, %Y\")`\noutput:\n\tunilur::tutorial_pdf:\n\t\tanswer: yes\n---"

--- a/man/answer_rmd.Rd
+++ b/man/answer_rmd.Rd
@@ -11,7 +11,7 @@ answer_rmd(yaml = NULL, suffix = "_answer", exclude = NULL)
 
 \item{suffix}{Suffix which is added to the filename (default is '_answer')}
 
-\item{exclude}{keyword for specific chunks that need to be excluded in answer templates (default NULL)}
+\item{exclude_chunk}{keyword to use for excluding specific chunks in answer templates (default NULL)}
 }
 \value{
 R Markdown output format to pass to \code{\link[rmarkdown]{render}}

--- a/man/answer_rmd.Rd
+++ b/man/answer_rmd.Rd
@@ -4,12 +4,14 @@
 \alias{answer_rmd}
 \title{Convert to a tutorial answer Rmarkdown file}
 \usage{
-answer_rmd(yaml = NULL, suffix = "_answer")
+answer_rmd(yaml = NULL, suffix = "_answer", exclude = NULL)
 }
 \arguments{
 \item{yaml}{a list to override the \code{title}, \code{author} and \code{output} of the answer Rmd file.}
 
 \item{suffix}{Suffix which is added to the filename (default is '_answer')}
+
+\item{exclude}{keyword for specific chunks that need to be excluded in answer templates (default NULL)}
 }
 \value{
 R Markdown output format to pass to \code{\link[rmarkdown]{render}}

--- a/man/answer_rmd.Rd
+++ b/man/answer_rmd.Rd
@@ -4,7 +4,7 @@
 \alias{answer_rmd}
 \title{Convert to a tutorial answer Rmarkdown file}
 \usage{
-answer_rmd(yaml = NULL, suffix = "_answer", exclude = NULL)
+answer_rmd(yaml = NULL, suffix = "_answer", exclude_chunk = NULL)
 }
 \arguments{
 \item{yaml}{a list to override the \code{title}, \code{author} and \code{output} of the answer Rmd file.}

--- a/man/examen_pdf.Rd
+++ b/man/examen_pdf.Rd
@@ -5,8 +5,15 @@
 \alias{examen_pdf_solution}
 \title{Convert to an examen PDF document}
 \usage{
-examen_pdf(solution = FALSE, suffix = "_question", id = FALSE,
-  mcq = "oneparchoices", includes = NULL, pandoc_args = NULL, ...)
+examen_pdf(
+  solution = FALSE,
+  suffix = "_question",
+  id = FALSE,
+  mcq = "oneparchoices",
+  includes = NULL,
+  pandoc_args = NULL,
+  ...
+)
 
 examen_pdf_solution(suffix = "_solution", ...)
 }
@@ -20,7 +27,7 @@ examen_pdf_solution(suffix = "_solution", ...)
 \item{mcq}{Theme for the multiple choice questions (\code{oneparchoices}, \code{oneparchoicesalt}, \code{oneparcheckboxesalt} or \code{oneparcheckboxes})}
 
 \item{includes}{Named list of additional content to include within the
-document (typically created using the \code{\link{includes}} function).}
+document (typically created using the \code{\link[rmarkdown]{includes}} function).}
 
 \item{pandoc_args}{Additional command line options to pass to pandoc}
 

--- a/man/tutorial_html.Rd
+++ b/man/tutorial_html.Rd
@@ -5,8 +5,14 @@
 \alias{tutorial_html_solution}
 \title{Convert to a tutorial HTML document}
 \usage{
-tutorial_html(solution = FALSE, suffix = "_question",
-  includes = NULL, css = NULL, extra_dependencies = NULL, ...)
+tutorial_html(
+  solution = FALSE,
+  suffix = "_question",
+  includes = NULL,
+  css = NULL,
+  extra_dependencies = NULL,
+  ...
+)
 
 tutorial_html_solution(suffix = "_solution", ...)
 }
@@ -16,15 +22,15 @@ tutorial_html_solution(suffix = "_solution", ...)
 \item{suffix}{Suffix which is added to the filename (default is '_question' for 'unilur::tutorial_html' and '_solution' for 'unilur::tutorial_html_solution')}
 
 \item{includes}{Named list of additional content to include within the
-document (typically created using the \code{\link{includes}} function).}
+document (typically created using the \code{\link[rmarkdown]{includes}} function).}
 
 \item{css}{One or more css files to include}
 
 \item{extra_dependencies}{Additional function arguments to pass to the
-base R Markdown HTML output formatter \code{\link{html_document_base}}}
+base R Markdown HTML output formatter \code{\link[rmarkdown]{html_document_base}}}
 
 \item{...}{Additional function arguments to pass to the
-base R Markdown HTML output formatter \code{\link{html_document_base}}}
+base R Markdown HTML output formatter \code{\link[rmarkdown]{html_document_base}}}
 }
 \value{
 R Markdown output format to pass to \code{\link[rmarkdown]{render}}

--- a/man/tutorial_pdf.Rd
+++ b/man/tutorial_pdf.Rd
@@ -5,8 +5,13 @@
 \alias{tutorial_pdf_solution}
 \title{Convert to a tutorial PDF document}
 \usage{
-tutorial_pdf(solution = FALSE, suffix = "_question",
-  pandoc_args = NULL, includes = NULL, ...)
+tutorial_pdf(
+  solution = FALSE,
+  suffix = "_question",
+  pandoc_args = NULL,
+  includes = NULL,
+  ...
+)
 
 tutorial_pdf_solution(suffix = "_solution", ...)
 }
@@ -18,7 +23,7 @@ tutorial_pdf_solution(suffix = "_solution", ...)
 \item{pandoc_args}{Additional command line options to pass to pandoc}
 
 \item{includes}{Named list of additional content to include within the
-document (typically created using the \code{\link{includes}} function).}
+document (typically created using the \code{\link[rmarkdown]{includes}} function).}
 
 \item{...}{Arguments passed to \code{pdf_document()}.}
 }


### PR DESCRIPTION
As an example, from

~~~
---
title: "project mammals sleep"
author: "AG"
date: "2020-06"
---
  
```{r setup-practical, child = '..practicals/_setup_practical.Rmd'}
```
if in between
```{r setup, include=FALSE}
knitr::opts_chunk$set(echo = TRUE)
library(tidyverse)
```

let's try 

```{r, solution = TRUE}
msleep
```

and
```{r}
1:2
```
~~~

we now obtain:

~~~
---
title: "My answers"
author: "My name"
date: '`r format(Sys.time(), "%d %B, %Y")`'
output: html_document
---
  

if in between

let's try 

```{r}
# Write your answer here
```


and
```{r}
1:2
```
~~~

so we removed 
~~~
```{r setup-practical, child = '..practicals/_setup_practical.Rmd'}
```
~~~

that was previously kept