### PR TITLE
enhances answer_rmd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: unilur
 Type: Package
 Title: rmarkdown template to prepare tutorials, practicals or examination papers
-Version: 0.4.0.9000
+Version: 0.4.0.9100
 Authors@R: c(person("Eric", "Koncina", , "mail@koncina.eu", c("aut", "cre")))
 Maintainer: Eric Koncina <mail@koncina.eu>
 Description: Rmarkdown template which creates tutorial files with the possibility to include/exclude the solutions.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Changes
 
 - `answer_rmd` default date in header is in ISO8601 format
+- `answer_rmd` stops accordingly to Rmd input when `knitr::knit_exit()` is found (unnamed R chunk with echo FALSE)
 
 
 # Unilur 0.4.0.9000

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# Unilur 0.4.0.9100
+
+## Changes
+
+- `answer_rmd` default date in header is in ISO8601 format
+
+
 # Unilur 0.4.0.9000
 
 ## Changes

--- a/R/answer_rmd.R
+++ b/R/answer_rmd.R
@@ -1,15 +1,15 @@
 #' Convert to a tutorial answer Rmarkdown file
 #'
 #' Format to generate a Rmd file with solutions chunks being replaced by empty answer chunks.
-#' 
+#'
 #' @param yaml a list to override the \code{title}, \code{author} and \code{output} of the answer Rmd file.
-#' 
+#'
 #' @param suffix Suffix which is added to the filename (default is '_answer')
-#' 
+#'
 #' @param exclude_chunk keyword to use for excluding specific chunks in answer templates (default NULL)
-#' 
+#'
 #' @return R Markdown output format to pass to \code{\link[rmarkdown]{render}}
-#' 
+#'
 #' @export
 answer_rmd <- function(yaml = NULL, suffix = "_answer", exclude_chunk = NULL) {
   # Here we implement a fake knitting: I don't think it's possible to avoid using pandoc
@@ -20,14 +20,15 @@ answer_rmd <- function(yaml = NULL, suffix = "_answer", exclude_chunk = NULL) {
   e$default_yaml <- list(
     title = "My answers",
     author = "My name",
+    date = format(Sys.time(), "%Y-%m-%d"),
     output = "html_document"
   )
   yaml <- check.options(yaml, name.opt = "default_yaml", envir = e)
-  
+
   format <- rmarkdown::md_document()
-  
+
   answer_output <- NULL
-  
+
   format$pre_knit <-  function(input, ...) {
     # Creating answer Rmd
     rmd <- paste(readLines(input), collapse = "\n")
@@ -40,7 +41,7 @@ answer_rmd <- function(yaml = NULL, suffix = "_answer", exclude_chunk = NULL) {
     rmd <- gsub(pattern, replacement, rmd, perl = TRUE)
     if (!is.null(exclude_chunk)) {
       # Removing chunk with specific keyword user provided
-      pattern <- paste0(" *``` *{.*(?i)", 
+      pattern <- paste0(" *``` *{.*(?i)",
                         as.character(exclude_chunk),
                         "(?-i).*} *\\n[\\s\\S]*?``` *")
       rmd <- gsub(pattern, "", rmd, perl = TRUE)
@@ -51,21 +52,21 @@ answer_rmd <- function(yaml = NULL, suffix = "_answer", exclude_chunk = NULL) {
     # Tab character seems not accepted by the custom yaml parser... Try to use the rmarkdown parser?
     #header <- sprintf("---\ntitle: \"%s\"\nauthor: \"%s\"\ndate: '`r format(Sys.time(), \"%%d %%B, %%Y\")`'\noutput: %s\n---",
     #                  yaml[["title"]], yaml[["author"]], yaml[["output"]])
-    
-    header <- do.call(sprintf, c(fmt = "---\ntitle: \"%s\"\nauthor: \"%s\"\ndate: '`r format(Sys.time(), \"%%d %%B, %%Y\")`'\noutput: %s\n---",
-                                 yaml[c("title", "author", "output")]))
-    
+
+    header <- do.call(sprintf, c(fmt = "---\ntitle: \"%s\"\nauthor: \"%s\"\ndate: \"%s\"\noutput: %s\n---",
+                                 yaml[c("title", "author", "date", "output")]))
+
     rmd <- gsub(pattern, header, rmd, perl = TRUE)
-    
+
     answer_output <<- paste0(tools::file_path_sans_ext(input), suffix, ".Rmd")
     writeLines(rmd, answer_output)
-    
+
     knitr::opts_hooks$set(eval = function(options) {
       options$eval <- FALSE
       options
     })
   }
-  
+
   format$post_processor <- function(metadata, input_file, output_file, clean, verbose) {
     # Removing knitted output_file we don't want and using the already created answer_output as the generated output_file
     unlink(output_file)

--- a/R/answer_rmd.R
+++ b/R/answer_rmd.R
@@ -38,7 +38,7 @@ answer_rmd <- function(yaml = NULL, suffix = "_answer", exclude_chunk = NULL) {
 
     # Delete lines after knit_exit(), might be worth checking if not eval = FALSE
     # Has to be a r unnamed chunk with echo false
-    rmd <- gsub("``` *\\{r,? (?i)echo(?-i) *= *(?i)(false|f)(?-i).*\\} *\\n.*knit_exit.+", "", rmd)
+    rmd <- gsub("\\n *``` *{r,? (?i)echo(?-i) *= *(?i)(false|f)(?-i).*} *\\n.*knit_exit[.\\s\\S]+", "", rmd, perl = TRUE)
 
     # Removing the chunks with either echo or eval set to FALSE
     pattern <- "\\n *``` *{.*(?i)(eval|echo|include)(?-i) *= *(?i)false(?-i).*} *\\n[\\s\\S]*?\\n *``` *"

--- a/R/answer_rmd.R
+++ b/R/answer_rmd.R
@@ -35,6 +35,11 @@ answer_rmd <- function(yaml = NULL, suffix = "_answer", exclude_chunk = NULL) {
     pattern <- "\\n *``` *{.*(?i)solution(?-i) *= *(?i)true(?-i).*} *\\n[\\s\\S]*?\\n *``` *"
     replacement <- "\n```{r}\n# Write your answer here\n```\n"
     rmd <- gsub(pattern, replacement, rmd, perl = TRUE)
+
+    # Delete lines after knit_exit(), might be worth checking if not eval = FALSE
+    # Has to be a r unnamed chunk with echo false
+    rmd <- gsub("``` *\\{r,? (?i)echo(?-i) *= *(?i)(false|f)(?-i).*\\} *\\n.*knit_exit.+", "", rmd)
+
     # Removing the chunks with either echo or eval set to FALSE
     pattern <- "\\n *``` *{.*(?i)(eval|echo|include)(?-i) *= *(?i)false(?-i).*} *\\n[\\s\\S]*?\\n *``` *"
     replacement <- ""
@@ -46,6 +51,7 @@ answer_rmd <- function(yaml = NULL, suffix = "_answer", exclude_chunk = NULL) {
                         "(?-i).*} *\\n[\\s\\S]*?``` *")
       rmd <- gsub(pattern, "", rmd, perl = TRUE)
     }
+
     # Replacing the original header by a custom one...
     pattern <- "^--- *\\n[\\s\\S]*?\\n *--- *"
     # header <- "---\ntitle: \"My answers\"\nauthor: \"My name\"\ndate: `r format(Sys.time(), \"%d %B, %Y\")`\noutput:\n\tunilur::tutorial_pdf:\n\t\tanswer: yes\n---"

--- a/man/tutorial_html.Rd
+++ b/man/tutorial_html.Rd
@@ -24,7 +24,10 @@ tutorial_html_solution(suffix = "_solution", ...)
 \item{includes}{Named list of additional content to include within the
 document (typically created using the \code{\link[rmarkdown]{includes}} function).}
 
-\item{css}{One or more css files to include}
+\item{css}{CSS and/or Sass files to include. Files with an extension of .sass
+or .scss are compiled to CSS via \code{sass::sass()}. Also, if \code{theme} is a
+\code{\link[bslib:bs_theme]{bslib::bs_theme()}} object, Sass code may reference the relevant Bootstrap
+Sass variables, functions, mixins, etc.}
 
 \item{extra_dependencies}{Additional function arguments to pass to the
 base R Markdown HTML output formatter \code{\link[rmarkdown]{html_document_base}}}


### PR DESCRIPTION
- `answer_rmd` default date in header is in ISO8601 format
- `answer_rmd` stops accordingly to Rmd input when `knitr::knit_exit()` is found (unnamed R chunk with echo FALSE)